### PR TITLE
Add 'engines'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   ],
   "author": "TJ Holowaychuk <tj@tjholowaychuk.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=5.0.0"
+  },
   "browserify": {
     "transform": [
       "babelify"


### PR DESCRIPTION
Node.js 4.x.x (npm 2.x.x) installs all dependencies of a third-party module into the module's node_modules folder.

`BIN_DIR` uses `node_modules/.bin` instead of `node_modules/react-fatigue-dev/.bin`. 

Let's drop 4.x.x and lower.
