### PR TITLE
Update Makefile to use a different babel cli setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 
 BIN_DIR ?= node_modules/.bin
-BUILD_DIR ?= build
-SRC ?= index.js
+BUILD_DIR ?= build/
+BUILD_FILES ?= build/
+SRC ?= src/
 
-BUILD_FLAGS ?=
+BUILD_FLAGS ?= --out-dir
 SERVER_FLAGS ?= -p 3000 example
 WATCH_FLAGS ?= example/index.js -p browserify-hmr -o example/bundle.js -dv
 
@@ -18,7 +19,7 @@ help:
 build: export NODE_ENV = production
 build:
 	@echo "  $(P) build"
-	@$(BIN_DIR)/babel $(BUILD_FLAGS) -d $(BUILD_DIR) $(SRC)
+	@rm -rf $(BUILD_DIR) && mkdir $(BUILD_DIR) && $(BIN_DIR)/babel $(SRC) $(BUILD_FLAGS) $(BUILD_FILES)
 
 start:
 	@$(MAKE) serve & $(MAKE) watch


### PR DESCRIPTION
I found this project extremely useful for testing and building esNext/react code into a general esModule.

When I using it for [a recent project](https://github.com/ekeric13/react-star-ratings) I found I had to put all my code into one file though. I modified the setup so I can put multiple files in a folder, and [all those files in that folder can be concatenated into one build/index.js file](https://github.com/ekeric13/react-star-ratings/blob/master/Makefile). Or, by default I have it setup so it takes each file in a folder, and transfers the compiled version into another folder.


This would cause a breaking change in the current repo as people have been using it with a source file in mind, not a source folder. So this probably shouldn't be merged in.

But it would be great if we could change [this line](https://github.com/tj/react-fatigue-dev/blob/master/Makefile#L21) so that it is more flexible in that it allows more than one file to be concatenated. With `-d` hardcoded in, as far as I can see, only one file can be compiled, even if it imports other files.